### PR TITLE
[Phase 2 Batch 3] Notifications and Convex unit tests

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,10 +12,12 @@
         "svix": "^1.89.0",
       },
       "devDependencies": {
+        "@edge-runtime/vm": "^5.0.0",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "convex-test": "^0.0.46",
         "eslint": "^9",
         "eslint-config-next": "16.2.1",
         "tailwindcss": "^4",
@@ -70,6 +72,10 @@
     "@clerk/react": ["@clerk/react@6.1.2", "", { "dependencies": { "@clerk/shared": "^4.3.2", "tslib": "2.8.1" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" } }, "sha512-hqghETUo8LLG+7pJQoRylFadwGNDrnLzM8n36SXr8T/ZyFqEmS1XzmiEZRi9xnKit1iFExpyiyA2nQW3HSCcvA=="],
 
     "@clerk/shared": ["@clerk/shared@4.3.2", "", { "dependencies": { "@tanstack/query-core": "5.90.16", "dequal": "2.0.3", "glob-to-regexp": "0.4.1", "js-cookie": "3.0.5", "std-env": "^3.9.0" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-tYYzdY4Fxb02TO4RHoLRFzEjXJn0iFDfoKhWtGyqf2AaIgkprTksunQtX0hnVssHMr3XD/E2S00Vrb+PzX3jCQ=="],
+
+    "@edge-runtime/primitives": ["@edge-runtime/primitives@6.0.0", "", {}, "sha512-FqoxaBT+prPBHBwE1WXS1ocnu/VLTQyZ6NMUBAdbP7N2hsFTTxMC/jMu2D/8GAlMQfxeuppcPuCUk/HO3fpIvA=="],
+
+    "@edge-runtime/vm": ["@edge-runtime/vm@5.0.0", "", { "dependencies": { "@edge-runtime/primitives": "6.0.0" } }, "sha512-NKBGBSIKUG584qrS1tyxVpX/AKJKQw5HgjYEnPLC0QsTw79JrGn+qUr8CXFb955Iy7GUdiiUv1rJ6JBGvaKb6w=="],
 
     "@emnapi/core": ["@emnapi/core@1.9.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" } }, "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA=="],
 
@@ -484,6 +490,8 @@
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "convex": ["convex@1.34.0", "", { "dependencies": { "esbuild": "0.27.0", "prettier": "^3.0.0", "ws": "8.18.0" }, "peerDependencies": { "@auth0/auth0-react": "^2.0.1", "@clerk/clerk-react": "^4.12.8 || ^5.0.0", "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0" }, "optionalPeers": ["@auth0/auth0-react", "@clerk/clerk-react", "react"], "bin": { "convex": "bin/main.js" } }, "sha512-TbC509Z4urZMChZR2aLPgalQ8gMhAYSz2VMxaYsCvba8YqB0Uxma7zWnXwRn7aEGXuA8ro5/uHgD1IJ0HhYYPg=="],
+
+    "convex-test": ["convex-test@0.0.46", "", { "peerDependencies": { "convex": "^1.32.0" } }, "sha512-Me4BqUUyJEKI2COvwCBKqnByNT0AZq6eKs9aTjpPX7mz3PSdmvRRP+Kt8VrWT4kCJ168X+hAEGKHPeH98ncSmg=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -14,6 +14,7 @@ import type * as bookings from "../bookings.js";
 import type * as cities from "../cities.js";
 import type * as cityRequests from "../cityRequests.js";
 import type * as lib_sanitize from "../lib/sanitize.js";
+import type * as notifications from "../notifications.js";
 import type * as performers from "../performers.js";
 import type * as planners from "../planners.js";
 import type * as users from "../users.js";
@@ -32,6 +33,7 @@ declare const fullApi: ApiFromModules<{
   cities: typeof cities;
   cityRequests: typeof cityRequests;
   "lib/sanitize": typeof lib_sanitize;
+  notifications: typeof notifications;
   performers: typeof performers;
   planners: typeof planners;
   users: typeof users;

--- a/convex/bookings.ts
+++ b/convex/bookings.ts
@@ -1,6 +1,26 @@
 import { v } from "convex/values";
+import type { MutationCtx } from "./_generated/server";
 import { mutation, query } from "./_generated/server";
 import { sanitizeText } from "./lib/sanitize";
+
+// --- Helpers ---
+
+async function notify(
+  ctx: MutationCtx,
+  userId: string,
+  type: string,
+  message: string,
+  relatedId?: string,
+) {
+  await ctx.db.insert("notifications", {
+    userId,
+    type,
+    message,
+    read: false,
+    relatedId,
+    createdAt: Date.now(),
+  });
+}
 
 // --- Mutations ---
 
@@ -41,7 +61,7 @@ export const createBookingRequest = mutation({
     }
 
     const now = Date.now();
-    return await ctx.db.insert("bookings", {
+    const bookingId = await ctx.db.insert("bookings", {
       venueId: args.venueId,
       performerId: args.performerId,
       requestedBy: args.requestedBy,
@@ -56,6 +76,17 @@ export const createBookingRequest = mutation({
       createdAt: now,
       updatedAt: now,
     });
+
+    // Notify the performer of the new booking request
+    await notify(
+      ctx,
+      performer.ownerId,
+      "booking_request",
+      `New booking request at ${venue.name} for ${args.eventDate}`,
+      bookingId,
+    );
+
+    return bookingId;
   },
 });
 
@@ -85,6 +116,14 @@ export const respondToBooking = mutation({
         updatedAt: now,
       });
 
+      await notify(
+        ctx,
+        booking.requestedBy,
+        "booking_accepted",
+        `Your booking request for ${booking.eventDate} was accepted`,
+        bookingId,
+      );
+
       // Auto-decline conflicting pending requests on the same date
       const pendingBookings = await ctx.db
         .query("bookings")
@@ -103,6 +142,13 @@ export const respondToBooking = mutation({
             status: "declined",
             updatedAt: now,
           });
+          await notify(
+            ctx,
+            other.requestedBy,
+            "booking_declined",
+            `Your booking for ${other.eventDate} was declined (performer booked another gig)`,
+            other._id,
+          );
         }
       }
     } else {
@@ -110,6 +156,13 @@ export const respondToBooking = mutation({
         status: "declined",
         updatedAt: now,
       });
+      await notify(
+        ctx,
+        booking.requestedBy,
+        "booking_declined",
+        `Your booking request for ${booking.eventDate} was declined`,
+        bookingId,
+      );
     }
 
     return bookingId;
@@ -145,6 +198,20 @@ export const cancelBooking = mutation({
       updatedAt: Date.now(),
     });
 
+    // Notify the other party
+    const performer = await ctx.db.get(booking.performerId);
+    const otherPartyUserId =
+      canceledBy === "performer" ? booking.requestedBy : performer?.ownerId;
+    if (otherPartyUserId) {
+      await notify(
+        ctx,
+        otherPartyUserId,
+        "booking_canceled",
+        `Booking for ${booking.eventDate} was canceled: ${reason}`,
+        bookingId,
+      );
+    }
+
     return bookingId;
   },
 });
@@ -178,6 +245,24 @@ export const markCompleted = mutation({
       status: "completed",
       updatedAt: Date.now(),
     });
+
+    const performer = await ctx.db.get(booking.performerId);
+    if (performer) {
+      await notify(
+        ctx,
+        performer.ownerId,
+        "booking_completed",
+        `Booking for ${booking.eventDate} marked as completed`,
+        bookingId,
+      );
+    }
+    await notify(
+      ctx,
+      booking.requestedBy,
+      "booking_completed",
+      `Booking for ${booking.eventDate} marked as completed`,
+      bookingId,
+    );
   },
 });
 

--- a/convex/cityRequests.ts
+++ b/convex/cityRequests.ts
@@ -91,6 +91,17 @@ export const approveCity = mutation({
     });
 
     await ctx.db.patch(requestId, { status: "approved" });
+
+    // Notify requester
+    await ctx.db.insert("notifications", {
+      userId: request.requestedBy,
+      type: "city_request_approved",
+      message: `Your city request for ${request.name}, ${request.stateOrRegion} was approved`,
+      read: false,
+      relatedId: requestId,
+      createdAt: Date.now(),
+    });
+
     return requestId;
   },
 });

--- a/convex/notifications.ts
+++ b/convex/notifications.ts
@@ -1,0 +1,78 @@
+import { v } from "convex/values";
+import { mutation, query, internalMutation } from "./_generated/server";
+
+// Internal mutation — called by other mutations to create notifications
+export const createNotification = internalMutation({
+  args: {
+    userId: v.string(),
+    type: v.string(),
+    message: v.string(),
+    relatedId: v.optional(v.string()),
+  },
+  handler: async (ctx, { userId, type, message, relatedId }) => {
+    return await ctx.db.insert("notifications", {
+      userId,
+      type,
+      message,
+      read: false,
+      relatedId,
+      createdAt: Date.now(),
+    });
+  },
+});
+
+export const getNotifications = query({
+  args: {
+    clerkId: v.string(),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, { clerkId, limit = 20 }) => {
+    const notifications = await ctx.db
+      .query("notifications")
+      .withIndex("by_userId_read", (q) => q.eq("userId", clerkId))
+      .collect();
+
+    return notifications
+      .sort((a, b) => b.createdAt - a.createdAt)
+      .slice(0, limit);
+  },
+});
+
+export const getUnreadCount = query({
+  args: { clerkId: v.string() },
+  handler: async (ctx, { clerkId }) => {
+    const unread = await ctx.db
+      .query("notifications")
+      .withIndex("by_userId_read", (q) =>
+        q.eq("userId", clerkId).eq("read", false),
+      )
+      .collect();
+
+    return unread.length;
+  },
+});
+
+export const markAsRead = mutation({
+  args: { notificationId: v.id("notifications") },
+  handler: async (ctx, { notificationId }) => {
+    await ctx.db.patch(notificationId, { read: true });
+  },
+});
+
+export const markAllAsRead = mutation({
+  args: { clerkId: v.string() },
+  handler: async (ctx, { clerkId }) => {
+    const unread = await ctx.db
+      .query("notifications")
+      .withIndex("by_userId_read", (q) =>
+        q.eq("userId", clerkId).eq("read", false),
+      )
+      .collect();
+
+    for (const n of unread) {
+      await ctx.db.patch(n._id, { read: true });
+    }
+
+    return { marked: unread.length };
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -91,6 +91,15 @@ export default defineSchema({
     .index("by_ownerId", ["ownerId"])
     .index("by_cityId", ["cityId"]),
 
+  notifications: defineTable({
+    userId: v.string(), // clerkId
+    type: v.string(),
+    message: v.string(),
+    read: v.boolean(),
+    relatedId: v.optional(v.string()),
+    createdAt: v.number(),
+  }).index("by_userId_read", ["userId", "read"]),
+
   bookings: defineTable({
     venueId: v.id("venues"),
     performerId: v.id("performers"),

--- a/convex/tests/availability.test.ts
+++ b/convex/tests/availability.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "vitest";
+import { createTest } from "./setup";
+import { api } from "../_generated/api";
+
+async function seedPerformer(t: ReturnType<typeof createTest>) {
+  return await t.run(async (ctx) => {
+    const cityId = await ctx.db.insert("cities", {
+      name: "Nashville",
+      stateOrRegion: "TN",
+      country: "US",
+      isActive: true,
+      createdAt: Date.now(),
+    });
+    await ctx.db.insert("users", {
+      clerkId: "perf_avail_1",
+      role: "performer",
+      cityId,
+      createdAt: Date.now(),
+    });
+    const performerId = await ctx.db.insert("performers", {
+      ownerId: "perf_avail_1",
+      stageName: "Availability Test",
+      genres: ["Jazz"],
+      bio: "Test",
+      cityId,
+      createdAt: Date.now(),
+    });
+    return { performerId };
+  });
+}
+
+describe("availability", () => {
+  test("setRecurringPatterns replaces all patterns", async () => {
+    const t = createTest();
+    const { performerId } = await seedPerformer(t);
+
+    await t.mutation(api.availability.setRecurringPatterns, {
+      performerClerkId: "perf_avail_1",
+      patterns: [
+        { dayOfWeek: 5, startTime: "20:00", endTime: "23:00" },
+        { dayOfWeek: 6, startTime: "20:00", endTime: "23:00" },
+      ],
+    });
+
+    const result = await t.query(api.availability.getAvailabilityForPerformer, {
+      performerId,
+    });
+    expect(result.patterns).toHaveLength(2);
+  });
+
+  test("addOverride creates a block", async () => {
+    const t = createTest();
+    const { performerId } = await seedPerformer(t);
+
+    await t.mutation(api.availability.addOverride, {
+      performerClerkId: "perf_avail_1",
+      date: "2026-05-20",
+      type: "block",
+    });
+
+    const result = await t.query(api.availability.getAvailabilityForPerformer, {
+      performerId,
+    });
+    expect(result.overrides).toHaveLength(1);
+    expect(result.overrides[0].type).toBe("block");
+  });
+
+  test("isPerformerAvailable returns false when blocked", async () => {
+    const t = createTest();
+    const { performerId } = await seedPerformer(t);
+
+    await t.mutation(api.availability.setRecurringPatterns, {
+      performerClerkId: "perf_avail_1",
+      patterns: [{ dayOfWeek: 5, startTime: "20:00", endTime: "23:00" }],
+    });
+    await t.mutation(api.availability.addOverride, {
+      performerClerkId: "perf_avail_1",
+      date: "2026-05-22", // Friday
+      type: "block",
+    });
+
+    const result = await t.query(api.availability.isPerformerAvailable, {
+      performerId,
+      date: "2026-05-22",
+    });
+    expect(result.available).toBe(false);
+  });
+});

--- a/convex/tests/bookings.test.ts
+++ b/convex/tests/bookings.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from "vitest";
+import { createTest } from "./setup";
+import { api } from "../_generated/api";
+
+async function seedFixture(t: ReturnType<typeof createTest>) {
+  return await t.run(async (ctx) => {
+    const cityId = await ctx.db.insert("cities", {
+      name: "Austin",
+      stateOrRegion: "TX",
+      country: "US",
+      isActive: true,
+      createdAt: Date.now(),
+    });
+
+    // Performer user + profile
+    await ctx.db.insert("users", {
+      clerkId: "performer_1",
+      role: "performer",
+      cityId,
+      createdAt: Date.now(),
+    });
+    const performerId = await ctx.db.insert("performers", {
+      ownerId: "performer_1",
+      stageName: "The Test Band",
+      genres: ["Rock"],
+      bio: "A test performer",
+      cityId,
+      createdAt: Date.now(),
+    });
+    // Weekly pattern: available every day
+    for (let day = 0; day < 7; day++) {
+      await ctx.db.insert("availabilityPatterns", {
+        performerId,
+        dayOfWeek: day,
+        startTime: "18:00",
+        endTime: "23:00",
+      });
+    }
+
+    // Venue user + profile
+    await ctx.db.insert("users", {
+      clerkId: "venue_1",
+      role: "venue_owner",
+      cityId,
+      createdAt: Date.now(),
+    });
+    const venueId = await ctx.db.insert("venues", {
+      ownerId: "venue_1",
+      name: "Test Venue",
+      address: "123 Test St",
+      cityId,
+      createdAt: Date.now(),
+    });
+
+    return { cityId, performerId, venueId };
+  });
+}
+
+describe("bookings", () => {
+  test("createBookingRequest creates pending booking", async () => {
+    const t = createTest();
+    const { performerId, venueId } = await seedFixture(t);
+
+    const bookingId = await t.mutation(api.bookings.createBookingRequest, {
+      requestedBy: "venue_1",
+      performerId,
+      venueId,
+      eventDate: "2026-05-10",
+      offeredRateCents: 50000,
+      startTime: "20:00",
+      endTime: "23:00",
+    });
+
+    const booking = await t.query(api.bookings.getBookingById, { bookingId });
+    expect(booking?.status).toBe("pending");
+    expect(booking?.offeredRateCents).toBe(50000);
+  });
+
+  test("respondToBooking accept transitions to accepted", async () => {
+    const t = createTest();
+    const { performerId, venueId } = await seedFixture(t);
+
+    const bookingId = await t.mutation(api.bookings.createBookingRequest, {
+      requestedBy: "venue_1",
+      performerId,
+      venueId,
+      eventDate: "2026-05-11",
+      offeredRateCents: 50000,
+      startTime: "20:00",
+      endTime: "23:00",
+    });
+
+    await t.mutation(api.bookings.respondToBooking, {
+      performerClerkId: "performer_1",
+      bookingId,
+      response: "accept",
+    });
+
+    const booking = await t.query(api.bookings.getBookingById, { bookingId });
+    expect(booking?.status).toBe("accepted");
+  });
+
+  test("conflicting request on accepted date is rejected", async () => {
+    const t = createTest();
+    const { performerId, venueId } = await seedFixture(t);
+
+    const firstId = await t.mutation(api.bookings.createBookingRequest, {
+      requestedBy: "venue_1",
+      performerId,
+      venueId,
+      eventDate: "2026-05-12",
+      offeredRateCents: 50000,
+      startTime: "20:00",
+      endTime: "23:00",
+    });
+    await t.mutation(api.bookings.respondToBooking, {
+      performerClerkId: "performer_1",
+      bookingId: firstId,
+      response: "accept",
+    });
+
+    await expect(
+      t.mutation(api.bookings.createBookingRequest, {
+        requestedBy: "venue_1",
+        performerId,
+        venueId,
+        eventDate: "2026-05-12",
+        offeredRateCents: 60000,
+        startTime: "20:00",
+        endTime: "23:00",
+      }),
+    ).rejects.toThrow();
+  });
+
+  test("invalid transition (pending -> completed) throws", async () => {
+    const t = createTest();
+    const { performerId, venueId } = await seedFixture(t);
+
+    const bookingId = await t.mutation(api.bookings.createBookingRequest, {
+      requestedBy: "venue_1",
+      performerId,
+      venueId,
+      eventDate: "2026-05-13",
+      offeredRateCents: 50000,
+      startTime: "20:00",
+      endTime: "23:00",
+    });
+
+    await expect(
+      t.mutation(api.bookings.markCompleted, { bookingId }),
+    ).rejects.toThrow();
+  });
+
+  test("cancelBooking records reason and canceledBy", async () => {
+    const t = createTest();
+    const { performerId, venueId } = await seedFixture(t);
+
+    const bookingId = await t.mutation(api.bookings.createBookingRequest, {
+      requestedBy: "venue_1",
+      performerId,
+      venueId,
+      eventDate: "2026-05-14",
+      offeredRateCents: 50000,
+      startTime: "20:00",
+      endTime: "23:00",
+    });
+
+    await t.mutation(api.bookings.cancelBooking, {
+      bookingId,
+      reason: "Event canceled",
+      canceledBy: "venue",
+    });
+
+    const booking = await t.query(api.bookings.getBookingById, { bookingId });
+    expect(booking?.status).toBe("canceled");
+    expect(booking?.canceledBy).toBe("venue");
+    expect(booking?.cancellationReason).toBe("Event canceled");
+  });
+});

--- a/convex/tests/notifications.test.ts
+++ b/convex/tests/notifications.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "vitest";
+import { createTest } from "./setup";
+import { api } from "../_generated/api";
+
+describe("notifications", () => {
+  test("getUnreadCount returns 0 when no notifications", async () => {
+    const t = createTest();
+    const count = await t.query(api.notifications.getUnreadCount, {
+      clerkId: "user_no_notifs",
+    });
+    expect(count).toBe(0);
+  });
+
+  test("booking request creates notification for performer", async () => {
+    const t = createTest();
+
+    const { performerId, venueId } = await t.run(async (ctx) => {
+      const cityId = await ctx.db.insert("cities", {
+        name: "Brooklyn",
+        stateOrRegion: "NY",
+        country: "US",
+        isActive: true,
+        createdAt: Date.now(),
+      });
+      await ctx.db.insert("users", {
+        clerkId: "notif_performer",
+        role: "performer",
+        cityId,
+        createdAt: Date.now(),
+      });
+      const performerId = await ctx.db.insert("performers", {
+        ownerId: "notif_performer",
+        stageName: "Notif Act",
+        genres: ["Rock"],
+        bio: "Test",
+        cityId,
+        createdAt: Date.now(),
+      });
+      await ctx.db.insert("availabilityPatterns", {
+        performerId,
+        dayOfWeek: 5,
+        startTime: "20:00",
+        endTime: "23:00",
+      });
+      await ctx.db.insert("users", {
+        clerkId: "notif_venue",
+        role: "venue_owner",
+        cityId,
+        createdAt: Date.now(),
+      });
+      const venueId = await ctx.db.insert("venues", {
+        ownerId: "notif_venue",
+        name: "Notif Venue",
+        address: "1 Test Rd",
+        cityId,
+        createdAt: Date.now(),
+      });
+      return { performerId, venueId };
+    });
+
+    await t.mutation(api.bookings.createBookingRequest, {
+      requestedBy: "notif_venue",
+      performerId,
+      venueId,
+      eventDate: "2026-06-05",
+      offeredRateCents: 50000,
+      startTime: "20:00",
+      endTime: "23:00",
+    });
+
+    const count = await t.query(api.notifications.getUnreadCount, {
+      clerkId: "notif_performer",
+    });
+    expect(count).toBe(1);
+
+    const notifications = await t.query(api.notifications.getNotifications, {
+      clerkId: "notif_performer",
+    });
+    expect(notifications[0].type).toBe("booking_request");
+  });
+
+  test("markAsRead decreases unread count", async () => {
+    const t = createTest();
+
+    const notificationId = await t.run(async (ctx) => {
+      return await ctx.db.insert("notifications", {
+        userId: "read_user",
+        type: "test",
+        message: "Test notification",
+        read: false,
+        createdAt: Date.now(),
+      });
+    });
+
+    expect(
+      await t.query(api.notifications.getUnreadCount, { clerkId: "read_user" }),
+    ).toBe(1);
+
+    await t.mutation(api.notifications.markAsRead, { notificationId });
+
+    expect(
+      await t.query(api.notifications.getUnreadCount, { clerkId: "read_user" }),
+    ).toBe(0);
+  });
+});

--- a/convex/tests/performers.test.ts
+++ b/convex/tests/performers.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, test } from "vitest";
+import { createTest } from "./setup";
+import { api } from "../_generated/api";
+
+describe("performers queries", () => {
+  test("getPerformersByCityId returns only city-scoped performers", async () => {
+    const t = createTest();
+
+    const { austinId, nashvilleId } = await t.run(async (ctx) => {
+      const austinId = await ctx.db.insert("cities", {
+        name: "Austin",
+        stateOrRegion: "TX",
+        country: "US",
+        isActive: true,
+        createdAt: Date.now(),
+      });
+      const nashvilleId = await ctx.db.insert("cities", {
+        name: "Nashville",
+        stateOrRegion: "TN",
+        country: "US",
+        isActive: true,
+        createdAt: Date.now(),
+      });
+      await ctx.db.insert("users", {
+        clerkId: "p_austin",
+        role: "performer",
+        cityId: austinId,
+        createdAt: Date.now(),
+      });
+      await ctx.db.insert("performers", {
+        ownerId: "p_austin",
+        stageName: "Austin Act",
+        genres: ["Rock"],
+        bio: "Austin",
+        cityId: austinId,
+        createdAt: Date.now(),
+      });
+      await ctx.db.insert("users", {
+        clerkId: "p_nashville",
+        role: "performer",
+        cityId: nashvilleId,
+        createdAt: Date.now(),
+      });
+      await ctx.db.insert("performers", {
+        ownerId: "p_nashville",
+        stageName: "Nashville Act",
+        genres: ["Country"],
+        bio: "Nashville",
+        cityId: nashvilleId,
+        createdAt: Date.now(),
+      });
+      return { austinId, nashvilleId };
+    });
+
+    const austin = await t.query(api.performers.getPerformersByCityId, {
+      cityId: austinId,
+    });
+    const nashville = await t.query(api.performers.getPerformersByCityId, {
+      cityId: nashvilleId,
+    });
+
+    expect(austin).toHaveLength(1);
+    expect(austin[0].stageName).toBe("Austin Act");
+    expect(nashville).toHaveLength(1);
+    expect(nashville[0].stageName).toBe("Nashville Act");
+  });
+
+  test("searchPerformers filters by genre", async () => {
+    const t = createTest();
+
+    const { cityId } = await t.run(async (ctx) => {
+      const cityId = await ctx.db.insert("cities", {
+        name: "Chicago",
+        stateOrRegion: "IL",
+        country: "US",
+        isActive: true,
+        createdAt: Date.now(),
+      });
+      await ctx.db.insert("users", {
+        clerkId: "p_rock",
+        role: "performer",
+        cityId,
+        createdAt: Date.now(),
+      });
+      await ctx.db.insert("performers", {
+        ownerId: "p_rock",
+        stageName: "Rock Band",
+        genres: ["Rock"],
+        bio: "Rock",
+        cityId,
+        createdAt: Date.now(),
+      });
+      await ctx.db.insert("users", {
+        clerkId: "p_jazz",
+        role: "performer",
+        cityId,
+        createdAt: Date.now(),
+      });
+      await ctx.db.insert("performers", {
+        ownerId: "p_jazz",
+        stageName: "Jazz Band",
+        genres: ["Jazz"],
+        bio: "Jazz",
+        cityId,
+        createdAt: Date.now(),
+      });
+      return { cityId };
+    });
+
+    const jazzResults = await t.query(api.performers.searchPerformers, {
+      cityId,
+      genres: ["Jazz"],
+    });
+    expect(jazzResults).toHaveLength(1);
+    expect(jazzResults[0].stageName).toBe("Jazz Band");
+  });
+
+  test("searchPerformers excludes suspended users", async () => {
+    const t = createTest();
+
+    const { cityId } = await t.run(async (ctx) => {
+      const cityId = await ctx.db.insert("cities", {
+        name: "Portland",
+        stateOrRegion: "OR",
+        country: "US",
+        isActive: true,
+        createdAt: Date.now(),
+      });
+      await ctx.db.insert("users", {
+        clerkId: "p_active",
+        role: "performer",
+        cityId,
+        status: "active",
+        createdAt: Date.now(),
+      });
+      await ctx.db.insert("performers", {
+        ownerId: "p_active",
+        stageName: "Active Act",
+        genres: ["Folk"],
+        bio: "Active",
+        cityId,
+        createdAt: Date.now(),
+      });
+      await ctx.db.insert("users", {
+        clerkId: "p_suspended",
+        role: "performer",
+        cityId,
+        status: "suspended",
+        createdAt: Date.now(),
+      });
+      await ctx.db.insert("performers", {
+        ownerId: "p_suspended",
+        stageName: "Suspended Act",
+        genres: ["Folk"],
+        bio: "Suspended",
+        cityId,
+        createdAt: Date.now(),
+      });
+      return { cityId };
+    });
+
+    const results = await t.query(api.performers.searchPerformers, { cityId });
+    expect(results).toHaveLength(1);
+    expect(results[0].stageName).toBe("Active Act");
+  });
+});

--- a/convex/tests/setup.ts
+++ b/convex/tests/setup.ts
@@ -1,0 +1,10 @@
+/// <reference types="vite/client" />
+import { convexTest } from "convex-test";
+import schema from "../schema";
+
+// Load all convex modules for the test runner
+const modules = import.meta.glob("../**/*.ts");
+
+export function createTest() {
+  return convexTest(schema, modules);
+}

--- a/convex/tests/users.test.ts
+++ b/convex/tests/users.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "vitest";
+import { createTest } from "./setup";
+import { api } from "../_generated/api";
+
+describe("users mutations", () => {
+  test("createUser inserts a new user", async () => {
+    const t = createTest();
+    const userId = await t.mutation(api.users.createUser, {
+      clerkId: "user_test_1",
+    });
+    expect(userId).toBeDefined();
+
+    const user = await t.query(api.users.getUserByClerkId, {
+      clerkId: "user_test_1",
+    });
+    expect(user).not.toBeNull();
+    expect(user?.clerkId).toBe("user_test_1");
+  });
+
+  test("createUser is idempotent", async () => {
+    const t = createTest();
+    const id1 = await t.mutation(api.users.createUser, {
+      clerkId: "user_test_2",
+    });
+    const id2 = await t.mutation(api.users.createUser, {
+      clerkId: "user_test_2",
+    });
+    expect(id1).toBe(id2);
+  });
+
+  test("setRole sets the user's role", async () => {
+    const t = createTest();
+    await t.mutation(api.users.createUser, { clerkId: "user_test_3" });
+    await t.mutation(api.users.setRole, {
+      clerkId: "user_test_3",
+      role: "performer",
+    });
+
+    const user = await t.query(api.users.getUserByClerkId, {
+      clerkId: "user_test_3",
+    });
+    expect(user?.role).toBe("performer");
+  });
+
+  test("setRole rejects changing an existing role", async () => {
+    const t = createTest();
+    await t.mutation(api.users.createUser, { clerkId: "user_test_4" });
+    await t.mutation(api.users.setRole, {
+      clerkId: "user_test_4",
+      role: "performer",
+    });
+    await expect(
+      t.mutation(api.users.setRole, {
+        clerkId: "user_test_4",
+        role: "venue_owner",
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -20,10 +20,12 @@
     "svix": "^1.89.0"
   },
   "devDependencies": {
+    "@edge-runtime/vm": "^5.0.0",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "convex-test": "^0.0.46",
     "eslint": "^9",
     "eslint-config-next": "16.2.1",
     "tailwindcss": "^4",

--- a/progress.txt
+++ b/progress.txt
@@ -33,8 +33,8 @@
     [x] W-000030 Planner books at a registered venue [P1]
     [x] W-000031 Planner books at an arbitrary location [P1]
     [x] W-000032 Performer public profile page [P1]
-    [ ] W-000033 In-app real-time notifications [P1]
-    [ ] W-000034 Convex schema and mutation unit tests [P1]
+    [x] W-000033 In-app real-time notifications [P1]
+    [x] W-000034 Convex schema and mutation unit tests [P1]
 
 [ ] Phase 3 - Trust and Reputation (8 stories)
     [ ] W-000035 Post-gig venue rates performer [P1]

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,6 +1,7 @@
 import { UserButton } from "@clerk/nextjs";
 import { getAuthenticatedUser } from "@/lib/auth";
 import { DashboardNav } from "@/components/dashboard-nav";
+import { NotificationBell } from "@/components/notification-bell";
 
 export default async function AppLayout({
   children,
@@ -20,6 +21,7 @@ export default async function AppLayout({
             <DashboardNav role={convexUser.role} />
           </div>
           <div className="flex items-center gap-3">
+            <NotificationBell />
             <span className="text-sm text-zinc-500 dark:text-zinc-400">
               {clerkUser.firstName ?? clerkUser.emailAddresses[0]?.emailAddress}
             </span>

--- a/src/components/notification-bell.tsx
+++ b/src/components/notification-bell.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery, useMutation } from "convex/react";
+import { useUser } from "@clerk/nextjs";
+import { api } from "../../convex/_generated/api";
+import type { Id } from "../../convex/_generated/dataModel";
+
+function timeAgo(timestamp: number): string {
+  const seconds = Math.floor((Date.now() - timestamp) / 1000);
+  if (seconds < 60) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  return new Date(timestamp).toLocaleDateString();
+}
+
+export function NotificationBell() {
+  const { user } = useUser();
+  const [open, setOpen] = useState(false);
+
+  const unreadCount = useQuery(
+    api.notifications.getUnreadCount,
+    user ? { clerkId: user.id } : "skip",
+  );
+  const notifications = useQuery(
+    api.notifications.getNotifications,
+    user && open ? { clerkId: user.id, limit: 20 } : "skip",
+  );
+  const markAsRead = useMutation(api.notifications.markAsRead);
+  const markAllAsRead = useMutation(api.notifications.markAllAsRead);
+
+  async function handleNotificationClick(
+    notificationId: Id<"notifications">,
+    read: boolean,
+  ) {
+    if (!read) {
+      await markAsRead({ notificationId });
+    }
+  }
+
+  async function handleMarkAllRead() {
+    if (!user) return;
+    await markAllAsRead({ clerkId: user.id });
+  }
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="relative rounded-full p-2 text-zinc-600 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-800"
+        aria-label="Notifications"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth={1.5}
+          stroke="currentColor"
+          className="h-5 w-5"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M14.857 17.082a23.848 23.848 0 0 0 5.454-1.31A8.967 8.967 0 0 1 18 9.75V9A6 6 0 0 0 6 9v.75a8.967 8.967 0 0 1-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 0 1-5.714 0m5.714 0a3 3 0 1 1-5.714 0"
+          />
+        </svg>
+        {unreadCount !== undefined && unreadCount > 0 && (
+          <span className="absolute -top-0.5 -right-0.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-red-600 px-1 text-[10px] font-medium text-white">
+            {unreadCount > 9 ? "9+" : unreadCount}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <>
+          <div
+            className="fixed inset-0 z-10"
+            onClick={() => setOpen(false)}
+          />
+          <div className="absolute right-0 top-full z-20 mt-2 w-80 rounded-lg border border-zinc-200 bg-white shadow-lg dark:border-zinc-800 dark:bg-zinc-900">
+            <div className="flex items-center justify-between border-b border-zinc-200 px-4 py-2 dark:border-zinc-800">
+              <h3 className="text-sm font-medium text-zinc-900 dark:text-zinc-50">
+                Notifications
+              </h3>
+              {unreadCount !== undefined && unreadCount > 0 && (
+                <button
+                  type="button"
+                  onClick={handleMarkAllRead}
+                  className="text-xs text-zinc-500 hover:text-zinc-900 dark:hover:text-zinc-50"
+                >
+                  Mark all read
+                </button>
+              )}
+            </div>
+            <div className="max-h-96 overflow-y-auto">
+              {!notifications ? (
+                <p className="p-4 text-sm text-zinc-500">Loading...</p>
+              ) : notifications.length === 0 ? (
+                <p className="p-4 text-sm text-zinc-500">
+                  No notifications yet.
+                </p>
+              ) : (
+                notifications.map((n) => (
+                  <button
+                    key={n._id}
+                    type="button"
+                    onClick={() => handleNotificationClick(n._id, n.read)}
+                    className={`flex w-full flex-col items-start gap-1 border-b border-zinc-100 px-4 py-3 text-left last:border-0 hover:bg-zinc-50 dark:border-zinc-800 dark:hover:bg-zinc-800 ${
+                      !n.read ? "bg-blue-50/50 dark:bg-blue-950/20" : ""
+                    }`}
+                  >
+                    <div className="flex w-full items-start justify-between gap-2">
+                      <p className="text-sm text-zinc-900 dark:text-zinc-50">
+                        {n.message}
+                      </p>
+                      {!n.read && (
+                        <span className="mt-1 h-2 w-2 shrink-0 rounded-full bg-blue-500" />
+                      )}
+                    </div>
+                    <span className="text-xs text-zinc-500">
+                      {timeAgo(n.createdAt)}
+                    </span>
+                  </button>
+                ))
+              )}
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,11 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    environment: "node",
+    environment: "edge-runtime",
+    server: {
+      deps: {
+        inline: ["convex-test"],
+      },
+    },
   },
 });


### PR DESCRIPTION
## Summary

### W-000033: In-app Notifications
- Add `notifications` table with userId/read index
- Create notification mutations/queries (create, get, getUnreadCount, markAsRead, markAllAsRead)
- Wire booking mutations to emit notifications for request/accept/decline/cancel/complete events
- Wire city request approval to notify requester
- Add `NotificationBell` component with unread badge and dropdown
- Add bell to app layout header

### W-000034: Convex Unit Tests
- Install convex-test + @edge-runtime/vm
- Configure Vitest for edge-runtime environment
- 18 unit tests covering users, bookings, availability, performers, notifications
- Tests verify state machine transitions, city scoping, genre filters, suspended user exclusion

## Test results
- `bun run test` → 18/18 passing
- `bun run build` → clean
- 20 routes registered

Closes #33, #34